### PR TITLE
use expect_snapshot() to test step printing

### DIFF
--- a/tests/testthat/_snaps/step_nest.md
+++ b/tests/testthat/_snaps/step_nest.md
@@ -1,0 +1,36 @@
+# step_nest works
+
+    Code
+      print(recipe)
+    Output
+      Recipe
+      
+      Inputs:
+      
+            role #variables
+         outcome          1
+       predictor          6
+      
+      Operations:
+      
+      Nest transformation with id
+
+---
+
+    Code
+      print(prepped_recipe)
+    Output
+      Recipe
+      
+      Inputs:
+      
+            role #variables
+         outcome          1
+       predictor          6
+      
+      Training data contained 1000 data points and no missing data.
+      
+      Operations:
+      
+      Nest transformation with id [trained]
+

--- a/tests/testthat/test-step_nest.R
+++ b/tests/testthat/test-step_nest.R
@@ -7,18 +7,16 @@ test_that("step_nest works", {
     tibble::tibble(id = NA, nest_id = NA_character_)
   )
 
-  expect_match(
-    purrr::quietly(print)(recipe)$output,
-    "Nest transformation"
+  expect_snapshot(
+    print(recipe)
   )
 
   prepped_recipe <- recipes::prep(recipe)
 
   expect_equal(tidy(prepped_recipe, 1), prepped_recipe$steps[[1]]$lookup_table)
 
-  expect_match(
-    purrr::quietly(print)(prepped_recipe)$output,
-    "Nest transformation"
+  expect_snapshot(
+    print(prepped_recipe)
   )
 
   expect_equal(


### PR DESCRIPTION
Hello @ashbythorpe 👋 

We are working on having {recipes} use {cli} for its printing needs here https://github.com/tidymodels/recipes/pull/1072.

In the revdepcheck for that PR I found that the way you are checking the printing of the recipes steps to be a little fragile. This PR modifies those test to use [snapshot tests](https://testthat.r-lib.org/articles/snapshotting.html) instead which will be more robust.

We will properly have that PR merged and submitted to CRAN in a month or so. So if you are able to update this package on CRAN before hand that would be awesome!