### PR TITLE
don't use glue::glue() in recipe step

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
     foreach,
     generics,
     ggplot2,
-    glue,
     lifecycle,
     magrittr,
     parsnip,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ Suggests:
     doParallel,
     ggrepel,
     glmnet,
+    glue,
     hardhat,
     knitr,
     parallel,

--- a/R/step_nest.R
+++ b/R/step_nest.R
@@ -129,7 +129,7 @@ prep.step_nest <- function(x, training, info = NULL, ...) {
     lookup_table <- training %>%
       tidyr::nest(data = -c(!!!rlang::syms(names))) %>%
       dplyr::ungroup() %>%
-      dplyr::mutate(.nest_id = glue::glue("Nest {1:dplyr::n()}")) %>%
+      dplyr::mutate(nest_id = factor(paste("Nest", 1:dplyr::n()))) %>%
       dplyr::select(-"data")
   } else {
     lookup_table <- NULL

--- a/R/step_nest.R
+++ b/R/step_nest.R
@@ -67,9 +67,9 @@
 #' sequence of any existing operations.
 #'
 #' @examples
-#' 
+#'
 #' library(recipes)
-#' 
+#'
 #' recipe <- recipe(example_nested_data, z ~ x + id) %>%
 #'   step_nest(id)
 #'
@@ -129,7 +129,7 @@ prep.step_nest <- function(x, training, info = NULL, ...) {
     lookup_table <- training %>%
       tidyr::nest(data = -c(!!!rlang::syms(names))) %>%
       dplyr::ungroup() %>%
-      dplyr::mutate(nest_id = factor(paste("Nest", 1:dplyr::n()))) %>%
+      dplyr::mutate(.nest_id = factor(paste("Nest", 1:dplyr::n()))) %>%
       dplyr::select(-"data")
   } else {
     lookup_table <- NULL


### PR DESCRIPTION
Hello @ashbythorpe 👋 

I was doing some work in recipes (https://github.com/tidymodels/recipes/pull/1199) and `step_nest()` came up in some testing. The step produces `glue` objects which recipes doesn't know how to handle: 

https://github.com/tidymodels/recipes/blob/914cdd443d49b77e22d2b651cb89aa23d0606e8a/R/misc.R#L158-L161

This PR changes the step so a factor is returned instead.

If you are able to pass this change along in a update on CRAN that would be very helpful. I'm planning to do a recipes release in about a month or so.